### PR TITLE
feat: add vite react frontend with tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Frontend artifacts
+frontend/node_modules/
+frontend/dist/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,16 @@
+# Frontend
+
+This project was bootstrapped with [Vite](https://vitejs.dev/) and configured with React, TypeScript, and Tailwind CSS. Design tokens live in `design-tokens.json` and are wired into `tailwind.config.ts`.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/frontend/design-tokens.json
+++ b/frontend/design-tokens.json
@@ -1,0 +1,28 @@
+{
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#ffffff"
+  },
+  "spacing": {
+    "1": "4px",
+    "2": "8px",
+    "3": "12px"
+  },
+  "radius": {
+    "none": "0px",
+    "sm": "4px",
+    "md": "8px"
+  },
+  "typography": {
+    "fontFamily": {
+      "sans": ["Inter", "sans-serif"],
+      "serif": ["Georgia", "serif"],
+      "mono": ["Menlo", "monospace"]
+    },
+    "fontSize": {
+      "base": ["16px", "24px"],
+      "lg": ["18px", "28px"],
+      "xl": ["20px", "32px"]
+    }
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold text-primary">Vite + React + TS + Tailwind</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+import tokens from './design-tokens.json';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
+  theme: {
+    extend: {
+      colors: tokens.colors,
+      spacing: tokens.spacing,
+      borderRadius: tokens.radius,
+      fontFamily: tokens.typography?.fontFamily,
+      fontSize: tokens.typography?.fontSize,
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts", "design-tokens.json"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold `frontend` Vite React TypeScript app
- add Tailwind CSS wired to `design-tokens.json`
- document dev and build steps

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pre-commit run --files .gitignore frontend/package.json frontend/tsconfig.json frontend/tsconfig.node.json frontend/vite.config.ts frontend/postcss.config.js frontend/tailwind.config.ts frontend/design-tokens.json frontend/index.html frontend/src/App.tsx frontend/src/main.tsx frontend/src/index.css frontend/README.md` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run dev` *(fails: vite: not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b39c22d1f88324bad7026cf5287bd3