### PR TITLE
feat: apply figma tokens

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
+@import "./styles/tokens.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,19 @@
+:root {
+  --colors-primary: #000000;
+  --colors-secondary: #ffffff;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --radius-none: 0px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --typography-fontFamily-sans: Inter, sans-serif;
+  --typography-fontFamily-serif: Georgia, serif;
+  --typography-fontFamily-mono: Menlo, monospace;
+  --typography-fontSize-base: 16px;
+  --typography-fontSize-base-line-height: 24px;
+  --typography-fontSize-lg: 18px;
+  --typography-fontSize-lg-line-height: 28px;
+  --typography-fontSize-xl: 20px;
+  --typography-fontSize-xl-line-height: 32px;
+}

--- a/frontend/src/utils/figma.ts
+++ b/frontend/src/utils/figma.ts
@@ -1,0 +1,62 @@
+export type DesignTokens = Record<string, any>;
+
+function toVarName(path: string[]): string {
+  return `--${path.join('-')}`;
+}
+
+export function tokensToCss(tokens: DesignTokens): string {
+  const lines: string[] = [':root {'];
+  const walk = (obj: any, path: string[]) => {
+    for (const [key, value] of Object.entries(obj)) {
+      const current = [...path, key];
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        walk(value, current);
+      } else if (Array.isArray(value)) {
+        if (value.length === 2) {
+          lines.push(`  ${toVarName(current)}: ${value[0]};`);
+          lines.push(`  ${toVarName([...current, 'line-height'])}: ${value[1]};`);
+        } else {
+          lines.push(`  ${toVarName(current)}: ${value.join(', ')};`);
+        }
+      } else {
+        lines.push(`  ${toVarName(current)}: ${value};`);
+      }
+    }
+  };
+  walk(tokens, []);
+  lines.push('}');
+  return lines.join('\n');
+}
+
+export function tokensToTailwind(tokens: DesignTokens): Record<string, any> {
+  const theme: Record<string, any> = {};
+  const mapVars = (obj: any, prefix: string[]): Record<string, any> => {
+    return Object.fromEntries(
+      Object.keys(obj).map((key) => [key, `var(--${[...prefix, key].join('-')})`])
+    );
+  };
+
+  if (tokens.colors) {
+    theme.colors = mapVars(tokens.colors, ['colors']);
+  }
+  if (tokens.spacing) {
+    theme.spacing = mapVars(tokens.spacing, ['spacing']);
+  }
+  if (tokens.radius) {
+    theme.borderRadius = mapVars(tokens.radius, ['radius']);
+  }
+  if (tokens.typography?.fontFamily) {
+    theme.fontFamily = mapVars(tokens.typography.fontFamily, ['typography', 'fontFamily']);
+  }
+  if (tokens.typography?.fontSize) {
+    const sizes: Record<string, any> = {};
+    for (const [key] of Object.entries(tokens.typography.fontSize)) {
+      sizes[key] = [
+        `var(--typography-fontSize-${key})`,
+        { lineHeight: `var(--typography-fontSize-${key}-line-height)` },
+      ];
+    }
+    theme.fontSize = sizes;
+  }
+  return theme;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,15 +1,33 @@
 import type { Config } from 'tailwindcss';
-import tokens from './design-tokens.json';
 
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
   theme: {
     extend: {
-      colors: tokens.colors,
-      spacing: tokens.spacing,
-      borderRadius: tokens.radius,
-      fontFamily: tokens.typography?.fontFamily,
-      fontSize: tokens.typography?.fontSize,
+      colors: {
+        primary: 'var(--colors-primary)',
+        secondary: 'var(--colors-secondary)',
+      },
+      spacing: {
+        '1': 'var(--spacing-1)',
+        '2': 'var(--spacing-2)',
+        '3': 'var(--spacing-3)',
+      },
+      borderRadius: {
+        none: 'var(--radius-none)',
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+      },
+      fontFamily: {
+        sans: 'var(--typography-fontFamily-sans)',
+        serif: 'var(--typography-fontFamily-serif)',
+        mono: 'var(--typography-fontFamily-mono)',
+      },
+      fontSize: {
+        base: ['var(--typography-fontSize-base)', { lineHeight: 'var(--typography-fontSize-base-line-height)' }],
+        lg: ['var(--typography-fontSize-lg)', { lineHeight: 'var(--typography-fontSize-lg-line-height)' }],
+        xl: ['var(--typography-fontSize-xl)', { lineHeight: 'var(--typography-fontSize-xl-line-height)' }],
+      },
     },
   },
   plugins: [],

--- a/scripts/apply-figma-tokens.ts
+++ b/scripts/apply-figma-tokens.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+import tokens from '../frontend/design-tokens.json';
+import { tokensToCss, tokensToTailwind } from '../frontend/src/utils/figma';
+
+const css = tokensToCss(tokens);
+const cssPath = path.resolve(__dirname, '../frontend/src/styles/tokens.css');
+fs.mkdirSync(path.dirname(cssPath), { recursive: true });
+fs.writeFileSync(cssPath, css + '\n');
+
+const theme = tokensToTailwind(tokens);
+const config = `import type { Config } from 'tailwindcss';\n\nexport default {\n  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],\n  theme: {\n    extend: ${JSON.stringify(theme, null, 2)}\n  },\n  plugins: [],\n} satisfies Config;\n`;
+
+const configPath = path.resolve(__dirname, '../frontend/tailwind.config.ts');
+fs.writeFileSync(configPath, config);


### PR DESCRIPTION
## Summary
- add utilities to convert Figma tokens to CSS variables and Tailwind theme
- script for generating tokens.css and updating Tailwind config
- wire generated tokens into Tailwind and styles

## Testing
- `npx ts-node scripts/apply-figma-tokens.ts` *(fails: 403 Forbidden fetching ts-node)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3b34d06d883248f45f1fa63bbc7f8