### PR TITLE
Dev containers for local Docker workflow (backend + optional Vite frontend)

### DIFF
--- a/.devcontainer/compose.dev.yml
+++ b/.devcontainer/compose.dev.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    command: >-
+      sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+  frontend:
+    image: node:20-alpine
+    working_dir: /workspace
+    volumes:
+      - ./frontend:/workspace
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - web

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "MingleMap (web)",
+  "dockerComposeFile": ["../docker-compose.yml", "compose.dev.yml"],
+  "service": "web",
+  "workspaceFolder": "/app",
+  "overrideCommand": true,
+  "postCreateCommand": "pip install -e .[dev] || (test -f requirements-dev.txt && pip install -r requirements-dev.txt) || (test -f requirements.txt && pip install -r requirements.txt) || true",
+  "remoteUser": "root",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-typescript-next"
+      ]
+    }
+  },
+  "forwardPorts": [8000, 5173],
+  "portsAttributes": {
+    "8000": { "label": "Django (dev)" },
+    "5173": { "label": "Vite (frontend)" }
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "ms-azuretools.vscode-docker",
+    "ms-vscode.vscode-typescript-next"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,17 @@
 {
-    // Format and import-sort on save
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
-    "python.formatting.blackArgs": ["--line-length", "88"],
-    "python.sortImports.args": ["--profile", "black"],
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
-    },
-    // pytest discovery
-    "python.testing.pytestEnabled": true,
-    "python.testing.autoTestDiscoverOnSaveEnabled": true
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": ["--line-length", "88"],
+  "python.sortImports.args": ["--profile", "black"],
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit"
+  },
+  "python.testing.pytestEnabled": true,
+  "python.testing.autoTestDiscoverOnSaveEnabled": true,
+  "python.analysis.typeCheckingMode": "basic",
+  "ruff.lint.args": ["--fix"],
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.pytest_cache": true
   }
-  
+}

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ minglemap                 # CLI hello world
 minglemap runserver       # Django dev server (auto‑reload)
 ```
 
+## Developing in VS Code Dev Containers
+
+1. Install Docker Desktop and VS Code with the Dev Containers and Docker extensions.
+2. Open the repo in VS Code, then run “Dev Containers: Reopen in Container”.
+3. Backend will be available at http://localhost:8000.
+4. If the `frontend` directory exists, the Vite dev server will be at http://localhost:5173 (either started via the override or manually with `cd frontend && npm install && npm run dev` inside the container).
+5. Useful commands: `docker compose up -d`, `docker compose logs -f`, `docker compose down -v`.
+
 ---
 
 ## About Lawrence Tech Guild


### PR DESCRIPTION
## Summary
- add VS Code dev container definition tied to docker-compose with frontend service
- recommend useful extensions and settings for Python and Vite development
- document how to develop using VS Code Dev Containers

## Testing
- [ ] `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml config`
- [ ] `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml up -d`
- [ ] `docker compose ps`
- [ ] `sleep 5 && curl -sS http://localhost:8000 || true`
- [ ] `sleep 5 && curl -sS http://localhost:5173/ || true`
- [ ] `docker compose logs -f --no-color --tail=100 web & sleep 15; pkill -f 'docker compose logs' || true`


------
https://chatgpt.com/codex/tasks/task_e_68b5d76fa3fc8324a535fed7d22024bd