### PR TITLE
chore: align devcontainer workspace mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "dockerComposeFile": ["../docker-compose.yml", "compose.dev.yml"],
   "service": "web",
   "workspaceFolder": "/app",
-  "overrideCommand": true,
+  "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
+  "overrideCommand": false,
   "postCreateCommand": "pip install -e .[dev] || (test -f requirements-dev.txt && pip install -r requirements-dev.txt) || (test -f requirements.txt && pip install -r requirements.txt) || true",
   "remoteUser": "root",
   "features": {


### PR DESCRIPTION
## Summary
- align devcontainer workspaceFolder with compose by adding explicit workspaceMount
- let container run its default command by disabling overrideCommand

## Testing
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml down` *(fails: command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml config` *(fails: command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml up -d` *(fails: command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml ps` *(fails: command not found: docker)*
- `sleep 5 && docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml ps` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fca057b883248cebc17629c781b4