### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# VCS
+.git
+.gitignore
+
+# Python cruft
+pycache/
+**/pycache/
+*.py[cod]
+*.pyo
+*.pyd
+*.pytest_cache/
+.pytest_cache/
+
+# Virtualenvs
+.venv/
+venv/
+
+# OS/editor
+.vscode/
+.vscode-server/
+.DS_Store
+Thumbs.db
+
+# Devcontainer metadata (not needed in build context)
+.devcontainer/**
+
+# Node / frontend build outputs
+node_modules/
+**/node_modules/
+frontend/node_modules/
+frontend/dist/
+frontend/.vite/
+
+# Logs and env
+.log
+.env
+.env.


### PR DESCRIPTION
## Summary
- ignore node_modules, virtualenvs, and other non-build files in Docker context to prevent devcontainer build failures

## Testing
- `pre-commit run --files .dockerignore` *(command not found: pre-commit)*
- `pip install pre-commit` *(could not find a version that satisfies the requirement pre-commit)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml down` *(command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml config` *(command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml build web` *(command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml up -d` *(command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml ps` *(command not found: docker)*
- `docker compose -f docker-compose.yml -f .devcontainer/compose.dev.yml logs --tail=80 web` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b601a374b083249786c56266ff2175