### PR TITLE
Add missing djangorestframework dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -161,6 +161,8 @@ django==5.2.1 \
     # via
     #   channels
     #   minglemap (pyproject.toml)
+djangorestframework==3.15.1
+    # via minglemap (pyproject.toml)
 hyperlink==21.0.0 \
     --hash=sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b \
     --hash=sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4


### PR DESCRIPTION
## Summary
- include djangorestframework in runtime requirements to support REST API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60e4442bc8324bcad1e223761c49f